### PR TITLE
Removed warnings and Linux typealias after migrating to Swift 3.1

### DIFF
--- a/Sources/Jobs.swift
+++ b/Sources/Jobs.swift
@@ -265,7 +265,7 @@ public final class Jobs {
     }
     
     //TODO(Brett):
-    @discardableResult
+	//@discardableResult
     static func schedule(
         _ days: Set<Day>,
         at: Time,
@@ -275,7 +275,7 @@ public final class Jobs {
     }
 
     //TODO(Brett):
-    @discardableResult
+    //@discardableResult
     public static func schedule(
         _ days: CountableRange<Day>,
         at: Time,
@@ -285,7 +285,7 @@ public final class Jobs {
     }
     
     //TODO(Brett):
-    @discardableResult
+    //@discardableResult
     static func schedule(
         _ days: CountableClosedRange<Day>,
         at: Time,

--- a/Sources/Shell.swift
+++ b/Sources/Shell.swift
@@ -4,9 +4,10 @@
 */
 import Foundation
 
-#if os(Linux)
-    typealias Process = Task
+#if !swift(>=3.1) && os(Linux)
+	typealias Process = Task
 #endif
+
 
 enum ShellError: Error {
     /// Thrown when the command didn't error but data failed to unwrap.


### PR DESCRIPTION
PR to merge the swift 3.1 improvements onto the latest release for vapor 1(0.1.1).